### PR TITLE
Cleaning fix point before showing stimulus

### DIFF
--- a/StroopTest/Views/ReactionPages/FormReactExposition.Designer.cs
+++ b/StroopTest/Views/ReactionPages/FormReactExposition.Designer.cs
@@ -75,7 +75,6 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.Manual;
             this.Text = "ReactionTest";
             this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
-            this.Paint += new System.Windows.Forms.PaintEventHandler(this.FormReactExposition_Paint);
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.exposition_KeyDown);
             this.ResumeLayout(false);
 

--- a/StroopTest/Views/ReactionPages/FormReactExposition.cs
+++ b/StroopTest/Views/ReactionPages/FormReactExposition.cs
@@ -518,6 +518,7 @@ namespace TestPlatform.Views
 
         private void showStimulus()
         {
+            this.CreateGraphics().Clear(ActiveForm.BackColor);
             if (executingTest.ProgramInUse.IsBeeping)
             {
                 MakeBeep();
@@ -961,9 +962,6 @@ namespace TestPlatform.Views
         {
             Graphics g = e.Graphics;
 
-
-            ExpositionController.makingFixPoint(executingTest.ProgramInUse.FixPoint, executingTest.ProgramInUse.FixPointColor,
-                this);
             Pen myPen = new Pen(ColorTranslator.FromHtml(colorsList[colorCounter]), 1);
             Point[] trianglePoints = createTrianglePoints();
             g.DrawPolygon(myPen, trianglePoints);
@@ -1027,11 +1025,6 @@ namespace TestPlatform.Views
             {
                 this.Controls.Remove((Control)e.UserState);
             }
-        }
-
-        private void FormReactExposition_Paint(object sender, PaintEventArgs e)
-        {
-            ExpositionController.makingFixPoint(executingTest.ProgramInUse.FixPoint, executingTest.ProgramInUse.FixPointColor, this);
         }
     }
 }


### PR DESCRIPTION
A implementação já fazia o ponto de fixação sumir no stroop, agora foi implementado no reaction test