### PR TITLE
181/Fixing severall bugs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,39 @@ You can run tests using visual studio default configurations.
 
 Please send a [GitHub Pull Request to TestPlatform](https://github.com/lab-neuro-comp/Test-Platform/pull/new/master) stating what you've done. 
 The Pull Request will only be accepted if the contribution works in all cultures (en-US and pt-BR).
+
+
+# Deployment
+
+
+
+For this project deployment, follow the steps below (You need  WinRAR to be installed in your computer)
+
+
+
+1. Change localization to specific culture that will be released. Don't forget to also change version in AssemblyInfo.cs (Inside Properties)
+
+
+![enter image description here](https://github.com/lab-neuro-comp/Test-Platform/blob/master/images/main_culture.png?raw=true)
+
+
+
+2. Go to project properties and click on the left menu on publish, changing application files accordingly to culture being published. Then, click on the Publish Wizard
+
+
+
+![enter image description here](https://github.com/lab-neuro-comp/Test-Platform/blob/master/images/publish_projects.png?raw=true)
+
+
+
+3. Right click on the folder created after published,  and click to add to file (using WinRAR).
+
+
+4. Use WinRAR advanced SFX options to create an executable of the compressed files
+
+
+![enter image description here](https://github.com/lab-neuro-comp/Test-Platform/blob/master/images/sfx_shortcut.png?raw=true)
+
+
+
+![enter image description here](https://github.com/lab-neuro-comp/Test-Platform/blob/master/images/sfx_text.png?raw=true)

--- a/StroopTest/Controllers/ExpositionController.cs
+++ b/StroopTest/Controllers/ExpositionController.cs
@@ -208,5 +208,27 @@
             }
 
         }
+        
+        public static void formSecondScreen(Form form)
+        {
+            Screen[] sc;
+            sc = Screen.AllScreens;
+            if (sc.Count<Screen>() > 1)
+            {
+                foreach (Screen s in sc)
+                {
+                    if (!s.Primary)
+                    {
+                        form.WindowState = FormWindowState.Maximized;
+                        form.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+                        form.Bounds = s.Bounds;
+                        form.MaximizeBox = true;
+                    }
+                }
+            }
+
+        }
+
+
     }
 }

--- a/StroopTest/Models/General/StrList.cs
+++ b/StroopTest/Models/General/StrList.cs
@@ -152,11 +152,12 @@ namespace TestPlatform.Models
             {
                 string listDestination = Global.testFilesPath + Global.listFolderName + ListName + Type + "/";
                 Directory.CreateDirectory(listDestination);
+                int i = 0;
                 foreach (string content in listContent)
                 {
                     try
                     {
-                        File.Copy(content, listDestination + Path.GetFileName(content), true);
+                        File.Copy(content, listDestination + i + Path.GetFileName(content), true);
 
                     }
                     catch
@@ -165,6 +166,7 @@ namespace TestPlatform.Models
                         CultureInfo currentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture;
                         MessageBox.Show(LocRM.GetString("fileNotFound", currentCulture) + "\n" + content);
                     }
+                    i++;
                 }
                 return true;
             }

--- a/StroopTest/Models/Tests/Reaction/ReactionProgram.cs
+++ b/StroopTest/Models/Tests/Reaction/ReactionProgram.cs
@@ -422,7 +422,7 @@ namespace TestPlatform.Models
 
             set
             {
-                if (!value || value && numberPositions == 0)
+                if (!value || value && numberPositions == 1)
                 {
                     expandImage = value;
                 }

--- a/StroopTest/Properties/AssemblyInfo.cs
+++ b/StroopTest/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0")]
-[assembly: AssemblyFileVersion("3.0")]
+[assembly: AssemblyVersion("3.1")]
+[assembly: AssemblyFileVersion("3.1")]
 

--- a/StroopTest/TestPlatform.csproj
+++ b/StroopTest/TestPlatform.csproj
@@ -17,7 +17,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <HockeyAppResourceId>4e4db72659e84ec1ab96ac2196fa1559</HockeyAppResourceId>
-    <PublishUrl>C:\Users\fabio\Desktop\UnB\Iniciação Científica\en-US\</PublishUrl>
+    <PublishUrl>C:\Users\fabio\Desktop\UnB\Iniciação Científica\pt-BR\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
     <UpdateEnabled>false</UpdateEnabled>
@@ -36,7 +36,7 @@
     <WebPage>publish.htm</WebPage>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>3.0.0.0</ApplicationVersion>
+    <ApplicationVersion>3.1.0.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <CreateDesktopShortcut>true</CreateDesktopShortcut>
     <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -532,7 +532,6 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Views\MatchingPages\FormMatchConfig.resx">
       <DependentUpon>FormMatchConfig.cs</DependentUpon>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Views\MatchingPages\MatchingExposition.resx">
       <DependentUpon>MatchingExposition.cs</DependentUpon>
@@ -736,8 +735,6 @@
     <None Include="Resources\bell.wav" />
     <None Include="Resources\error.wav" />
     <None Include="Resources\hit.wav" />
-    <None Include="Resources\helpToolTipMatrixImage.bmp" />
-    <None Include="Resources\helpPagesImages\positionMap.png" />
     <Content Include="Resources\icons\circle.png" />
     <Content Include="Resources\icons\cross.png" />
     <Content Include="Resources\icons\helpButton.png" />
@@ -803,7 +800,7 @@
       <Group>en-US</Group>
       <TargetPath>
       </TargetPath>
-      <PublishState>Include</PublishState>
+      <PublishState>Exclude</PublishState>
       <IncludeHash>True</IncludeHash>
       <FileType>Satellite</FileType>
     </PublishFile>
@@ -812,7 +809,7 @@
       <Group>pt-BR</Group>
       <TargetPath>
       </TargetPath>
-      <PublishState>Exclude</PublishState>
+      <PublishState>Include</PublishState>
       <IncludeHash>True</IncludeHash>
       <FileType>Satellite</FileType>
     </PublishFile>

--- a/StroopTest/Views/ListsPages/FormImgConfig.cs
+++ b/StroopTest/Views/ListsPages/FormImgConfig.cs
@@ -41,8 +41,6 @@ namespace TestPlatform
 
         private void openImgList()
         {
-            try
-            {
                 FormDefine defineFilePath = defineFilePath = new FormDefine(LocRM.GetString("imageList", currentCulture), Global.testFilesPath + Global.listFolderName, "dir","_image",true, false);
                 var result = defineFilePath.ShowDialog();
                 
@@ -55,17 +53,13 @@ namespace TestPlatform
                         isListNameValid = false;
                         return;
                     }
-                    imgListNameTextBox.Text = listName.Remove(listName.Length - 6); // removes the _img identification from file while editing (when its saved it is always added again)
+                    imgListNameTextBox.Text = listName; // removes the _img identification from file while editing (when its saved it is always added again)
                     imageList = new StrList(listName, IMAGE);
                     string[] filePaths = imageList.ListContent.ToArray();
                     readImagesIntoDGV(filePaths, imgPathDataGridView);                  
 
                 }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message);
-            }
+         
         }
 
         private void btnOpen_Click(object sender, EventArgs e)

--- a/StroopTest/Views/ListsPages/FormImgConfig.resx
+++ b/StroopTest/Views/ListsPages/FormImgConfig.resx
@@ -297,12 +297,27 @@
   <metadata name="fileNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="fileNameColumn.HeaderText" xml:space="preserve">
+    <value>Nome do Arquivo</value>
+  </data>
+  <data name="fileNameColumn.Width" type="System.Int32, mscorlib">
+    <value>120</value>
+  </data>
   <metadata name="thumbnailColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="thumbnailColumn.HeaderText" xml:space="preserve">
+    <value>Imagem</value>
+  </data>
+  <data name="thumbnailColumn.Width" type="System.Int32, mscorlib">
+    <value>120</value>
+  </data>
   <metadata name="filePathColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="filePathColumn.HeaderText" xml:space="preserve">
+    <value>Localização</value>
+  </data>
   <data name="imgPathDataGridView.Location" type="System.Drawing.Point, System.Drawing">
     <value>25, 357</value>
   </data>
@@ -326,30 +341,6 @@
   </data>
   <data name="&gt;&gt;imgPathDataGridView.ZOrder" xml:space="preserve">
     <value>11</value>
-  </data>
-  <metadata name="fileNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="fileNameColumn.HeaderText" xml:space="preserve">
-    <value>Nome do Arquivo</value>
-  </data>
-  <data name="fileNameColumn.Width" type="System.Int32, mscorlib">
-    <value>120</value>
-  </data>
-  <metadata name="thumbnailColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="thumbnailColumn.HeaderText" xml:space="preserve">
-    <value>Imagem</value>
-  </data>
-  <data name="thumbnailColumn.Width" type="System.Int32, mscorlib">
-    <value>120</value>
-  </data>
-  <metadata name="filePathColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <data name="filePathColumn.HeaderText" xml:space="preserve">
-    <value>Localização</value>
   </data>
   <data name="moveUpButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left</value>
@@ -625,7 +616,7 @@
     <value>True</value>
   </data>
   <data name="numberFiles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>133, 351</value>
+    <value>133, 337</value>
   </data>
   <data name="numberFiles.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 0, 4, 0</value>

--- a/StroopTest/Views/MatchingPages/MatchingExposition.cs
+++ b/StroopTest/Views/MatchingPages/MatchingExposition.cs
@@ -138,11 +138,14 @@ namespace TestPlatform.Views.MatchingPages
             this.FormBorderStyle = FormBorderStyle.None;
             this.MaximizeBox = true;
             this.StartPosition = FormStartPosition.Manual;
+            ExpositionController.formSecondScreen(this);
+
             InitializeComponent();
             startTime = hour + "_" + minutes + "_" + seconds;
             executingTest.ParticipantName = participantName;
             executingTest.setProgramInUse(path + "/prg/", prgName);
             executingTest.Mark = mark;
+
             stimuluControls = new List<Control>();
             outputFile = outputDataPath + executingTest.ParticipantName + "_" + executingTest.ProgramInUse.ProgramName + ".txt";
             startExposition();

--- a/StroopTest/Views/ReactionPages/FormReactExposition.cs
+++ b/StroopTest/Views/ReactionPages/FormReactExposition.cs
@@ -75,6 +75,7 @@ namespace TestPlatform.Views
             this.FormBorderStyle = FormBorderStyle.None;
             this.MaximizeBox = true;
             this.StartPosition = FormStartPosition.Manual;
+            ExpositionController.formSecondScreen(this);
             InitializeComponent();
             startTime = hour + "_" + minutes + "_" + seconds;
             executingTest.ParticipantName = participantName;

--- a/StroopTest/Views/ReactionPages/FormReactExposition.cs
+++ b/StroopTest/Views/ReactionPages/FormReactExposition.cs
@@ -716,14 +716,15 @@ namespace TestPlatform.Views
 
         private void intervalBW_DoWork(object sender, DoWorkEventArgs e)
         {
-            ExpositionController.makingFixPoint(executingTest.ProgramInUse.FixPoint, executingTest.ProgramInUse.FixPointColor,
-                this);
+            
 
             executingTest.InitialTime = DateTime.Now;
             accumulativeStopWatch.Start();
 
             for (int counter = 0; counter < executingTest.ProgramInUse.NumExpositions && !cancelExposition; counter++)
             {
+                ExpositionController.makingFixPoint(executingTest.ProgramInUse.FixPoint, executingTest.ProgramInUse.FixPointColor,
+                this);
                 currentExposition = counter;
                 //preparing execution
                 expositionBackground();

--- a/StroopTest/Views/ReactionPages/FormReactExposition.cs
+++ b/StroopTest/Views/ReactionPages/FormReactExposition.cs
@@ -1024,11 +1024,11 @@ namespace TestPlatform.Views
         private void intervalBW_ProgressChanged(object sender, ProgressChangedEventArgs e)
         {
 
-            if (exposing)
+            if (exposing && !cancelExposition)
             {
                 this.Controls.Add((Control)e.UserState);
             }
-            else
+            else if (!cancelExposition)
             {
                 this.Controls.Remove((Control)e.UserState);
             }

--- a/StroopTest/Views/ReactionPages/FormReactExposition.cs
+++ b/StroopTest/Views/ReactionPages/FormReactExposition.cs
@@ -832,7 +832,7 @@ namespace TestPlatform.Views
         /* creates a x and y vector on center of the screen */
         private Point centerShapePosition(Size size)
         {
-            currentPosition = 0;
+            currentPosition = 2;
             StimulusPosition stimulusPosition = new StimulusPosition(ClientSize, size);
             Point newPoint = stimulusPosition.threePointsPosition(currentPosition);
             currentPositionOutput = stimulusPosition.CurrentPosition;

--- a/StroopTest/Views/ReactionPages/FormTRConfig.resx
+++ b/StroopTest/Views/ReactionPages/FormTRConfig.resx
@@ -178,7 +178,7 @@
     <value>1</value>
   </data>
   <data name="userResponse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>399, 391</value>
+    <value>399, 404</value>
   </data>
   <data name="userResponse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -397,7 +397,7 @@
     <value>0</value>
   </data>
   <data name="shapesGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>399, 166</value>
+    <value>399, 179</value>
   </data>
   <data name="shapesGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -671,7 +671,7 @@ Ponto:</value>
     <value>7</value>
   </data>
   <data name="fixPointGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>399, 283</value>
+    <value>399, 296</value>
   </data>
   <data name="fixPointGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -782,7 +782,7 @@ Ponto:</value>
     <value>2</value>
   </data>
   <data name="othersGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>399, 471</value>
+    <value>399, 484</value>
   </data>
   <data name="othersGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -1034,7 +1034,7 @@ Ponto:</value>
     <value>7</value>
   </data>
   <data name="timeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>399, 33</value>
+    <value>399, 46</value>
   </data>
   <data name="timeGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -1307,7 +1307,7 @@ Ponto:</value>
     <value>7</value>
   </data>
   <data name="S.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 383</value>
+    <value>13, 396</value>
   </data>
   <data name="S.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -1337,7 +1337,7 @@ Ponto:</value>
     <value>6</value>
   </data>
   <data name="instructionsBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 555</value>
+    <value>13, 568</value>
   </data>
   <data name="instructionsBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -2154,7 +2154,7 @@ Ponto:</value>
     <value>25</value>
   </data>
   <data name="expositionGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 33</value>
+    <value>13, 46</value>
   </data>
   <data name="expositionGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -2187,7 +2187,7 @@ Ponto:</value>
     <value>True</value>
   </data>
   <data name="instructionsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 537</value>
+    <value>13, 550</value>
   </data>
   <data name="instructionsLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>77, 17</value>
@@ -2274,7 +2274,7 @@ Ponto:</value>
     <value>3, 2, 3, 2</value>
   </data>
   <data name="reactionConfigPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>794, 674</value>
+    <value>794, 686</value>
   </data>
   <data name="reactionConfigPanel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2298,7 +2298,7 @@ Ponto:</value>
     <value>Popup</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 681</value>
+    <value>4, 696</value>
   </data>
   <data name="cancelButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
@@ -2331,7 +2331,7 @@ Ponto:</value>
     <value>Popup</value>
   </data>
   <data name="saveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>696, 681</value>
+    <value>696, 696</value>
   </data>
   <data name="saveButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>

--- a/StroopTest/Views/StroopPages/FormExposition.cs
+++ b/StroopTest/Views/StroopPages/FormExposition.cs
@@ -74,6 +74,9 @@ namespace TestPlatform
             currentTest.Mark = mark;
             currentTest.InitialDate = DateTime.Now;
 
+
+            ExpositionController.formSecondScreen(this);
+
             configureCurrentTest();
             startExpo();
             this.ShowDialog();

--- a/StroopTest/Views/StroopPages/FormExposition.cs
+++ b/StroopTest/Views/StroopPages/FormExposition.cs
@@ -55,6 +55,8 @@ namespace TestPlatform
         private string currentStimulus = "false";
         private string currentAudio = "false";
         private int wordCounter = 0, colorCounter = 0, audiocounter = 0, subtitlecounter = 0, imageCounter = 0;
+        private bool isRecordingSaved = false;
+
         /// <summary>
         /// This is the constructor method for stroop test exposition form.</summary>
         /// <param name="prgName"> Program name is the name of the current StroopProgram that wil be executed.</param>
@@ -105,10 +107,6 @@ namespace TestPlatform
             {
                 runExposition = false;
                 cts.Cancel();
-
-                this.Close();
-                this.Dispose();
-                this.DialogResult = DialogResult.Cancel;
             }
             return base.ProcessCmdKey(ref msg, keyData);
         }
@@ -299,7 +297,11 @@ namespace TestPlatform
             }
             catch (TaskCanceledException)
             {
-                StroopProgram.writeOutputFile(outputFile, string.Join("\n", outputContent.ToArray()));
+                if (currentTest.ProgramInUse.AudioCapture)
+                {
+                    stopRecordingAudio();
+                }
+                finishExposition();
             }
             catch (Exception ex)
             {
@@ -352,7 +354,7 @@ namespace TestPlatform
             catch (TaskCanceledException)
             {
                 Player.Stop();
-                StroopProgram.writeOutputFile(outputFile, string.Join("\n", outputContent.ToArray()));
+                finishExposition();
             }
             catch (Exception ex)
             {
@@ -540,12 +542,11 @@ namespace TestPlatform
             }
             catch (TaskCanceledException)
             {
-                StroopProgram.writeOutputFile(outputFile, string.Join("\n", outputContent.ToArray()));
-                // beginAudio
                 if (currentTest.ProgramInUse.AudioCapture)
                 {
                     stopRecordingAudio();
                 }
+                finishExposition();
             }
             catch (Exception ex)
             {
@@ -639,12 +640,11 @@ namespace TestPlatform
             }
             catch (TaskCanceledException)
             {
-                StroopProgram.writeOutputFile(outputFile, string.Join("\n", outputContent.ToArray()));
-                // beginAudio
                 if (currentTest.ProgramInUse.AudioCapture)
                 {
                     stopRecordingAudio();
                 }
+                finishExposition();
             }
             catch (Exception ex)
             {
@@ -719,7 +719,7 @@ namespace TestPlatform
                 {
                     stopRecordingAudio();
                 }
-                StroopProgram.writeOutputFile(outputFile, string.Join("\n", outputContent.ToArray()));
+                finishExposition();
             }
             catch (Exception ex)
             {

--- a/StroopTest/Views/StroopPages/FormExposition.cs
+++ b/StroopTest/Views/StroopPages/FormExposition.cs
@@ -55,7 +55,6 @@ namespace TestPlatform
         private string currentStimulus = "false";
         private string currentAudio = "false";
         private int wordCounter = 0, colorCounter = 0, audiocounter = 0, subtitlecounter = 0, imageCounter = 0;
-        private bool isRecordingSaved = false;
 
         /// <summary>
         /// This is the constructor method for stroop test exposition form.</summary>
@@ -760,15 +759,23 @@ namespace TestPlatform
 
         private async Task showInstructions(StroopProgram program, CancellationToken token) 
         {
-            if (program.InstructionText != null)
+            try
             {
-                instructionLabel.Enabled = true; instructionLabel.Visible = true;
-                for (int i = 0; i < program.InstructionText.Count; i++)
+                if (program.InstructionText != null)
                 {
-                    instructionLabel.Text = program.InstructionText[i];
-                    await Task.Delay(Program.instructionAwaitTime);
+                    instructionLabel.Enabled = true; instructionLabel.Visible = true;
+                    for (int i = 0; i < program.InstructionText.Count; i++)
+                    {
+                        instructionLabel.Text = program.InstructionText[i];
+                        await Task.Delay(Program.instructionAwaitTime, token);
+                    }
+                    instructionLabel.Enabled = false; instructionLabel.Visible = false;
                 }
-                instructionLabel.Enabled = false; instructionLabel.Visible = false;
+            }
+            catch (TaskCanceledException)
+            {
+                this.DialogResult = DialogResult.OK;
+                Close();
             }
         }
 


### PR DESCRIPTION
Fixed:

- Agora a exposição do tr de 1 posição aparece centralizada (estava na esquerda)

- Agora o formulário de editar imagem preenche o nome da lista corretamente

- A exceção ao tentar adicionar a propriedade "expandir imagem" no tr foi corrigida"

- A exceção ao tentar editar lista de imagem deixou de ser tratada (agora nada aparece para o usuário, qual era a causa raíz? o problema era a tentativa de retirar a terminação "_image" em listas que possuiam menos de 6 caracteres)