### PR TITLE
179/Conversão de pixels para centímetros

### DIFF
--- a/StroopTest/Controllers/ExpositionController.cs
+++ b/StroopTest/Controllers/ExpositionController.cs
@@ -150,11 +150,12 @@
             }
         }
 
-        public static PictureBox InitializeImageBox(int stimuliSize, Image image, bool expandImage)
+        public static PictureBox InitializeImageBox(double stimuliSize, Image image, bool expandImage, Form form)
         {
             PictureBox newPictureBox = new PictureBox();
+            int size = CentimeterToPixel(stimuliSize, form);
             newPictureBox.SizeMode = PictureBoxSizeMode.StretchImage;
-            newPictureBox.Size = new Size(stimuliSize, stimuliSize);
+            newPictureBox.Size = new Size(size, size);
 
             newPictureBox.Image = image;
             newPictureBox.Enabled = true;
@@ -227,6 +228,16 @@
                 }
             }
 
+        }
+
+        public static int CentimeterToPixel(double Centimeter, Form form)
+        {
+            double pixel = -1;
+            using (Graphics g = form.CreateGraphics())
+            {
+                pixel = Centimeter * g.DpiY / 2.54d;
+            }
+            return (int)pixel;
         }
 
 

--- a/StroopTest/Models/Tests/Reaction/ReactionProgram.cs
+++ b/StroopTest/Models/Tests/Reaction/ReactionProgram.cs
@@ -9,7 +9,7 @@ namespace TestPlatform.Models
 {
     class ReactionProgram : Program
     {
-        private Int32 stimuluSize; // [3]
+        private double stimuluSize; // [3]
         private Boolean isBeeping; // [9]
         private Boolean beepingRandom; // [19]
         private Int32 beepDuration; // [10]
@@ -43,7 +43,7 @@ namespace TestPlatform.Models
         /// <summary>
         /// This constructor is used to create a reaction program with shapes
         /// </summary>
-        public ReactionProgram(string programName, int expositionTime, int numExpositions, int stimuluSize, int intervalTime,
+        public ReactionProgram(string programName, int expositionTime, int numExpositions, double stimuluSize, int intervalTime,
                                 bool isBeeping, int beepDuration, string stimulusColor,
                                 string fixPoint, string backgroundColor, string fixPointColor, bool intervalTimeRandom,
                                 string stimuluShape, bool beepRandom, int numberPositions,
@@ -102,7 +102,7 @@ namespace TestPlatform.Models
         {
             // ReactionProgram properties
             this.expositionType = "words";
-            this.stimuluSize = stimuluSize;
+            this.fontSize = stimuluSize;
             this.isBeeping = isBeeping;
             this.beepDuration = beepDuration;
             this.FontSize = fontSize;
@@ -125,10 +125,11 @@ namespace TestPlatform.Models
                 this.setColorListFile(colorList);
             }
 
-            //default configurations for shapes version of ReactionProgram
+            //default configurations for words version of ReactionProgram
             this.setAudioListFile("false");
             this.setImageListFile("false");
             this.ExpandImage = false;
+            this.stimuluSize = 10;
 
             // Program properties
             this.programName = programName;
@@ -146,7 +147,7 @@ namespace TestPlatform.Models
         /// <summary>
         /// This constructor is used to create a reaction program with image type
         /// </summary>
-        public ReactionProgram(string programName, int expositionTime, int numExpositions, int stimuluSize, int intervalTime,
+        public ReactionProgram(string programName, int expositionTime, int numExpositions, double stimuluSize, int intervalTime,
                         bool isBeeping, int beepDuration,
                         string fixPoint, string backgroundColor, string fixPointColor, bool intervalTimeRandom,
                         string imageList, bool beepRandom, int numberPositions,
@@ -188,7 +189,7 @@ namespace TestPlatform.Models
         /// <summary>
         /// This constructor is used to create a reaction program with image and words
         /// </summary>
-        public ReactionProgram(string programName, int expositionTime, int numExpositions, int stimuluSize, int intervalTime,
+        public ReactionProgram(string programName, int expositionTime, int numExpositions, double stimuluSize, int intervalTime,
                         bool isBeeping, int beepDuration,
                         string fixPoint, string backgroundColor, string fixPointColor, bool intervalTimeRandom,
                         string imageList, string wordList,  string colorList, bool beepRandom, int numberPositions,
@@ -295,7 +296,7 @@ namespace TestPlatform.Models
         /// </summary>
         public ReactionProgram(string programName, int expositionTime, int numExpositions, int intervalTime,
                                 string fixPoint, string backgroundColor, string fixPointColor, bool intervalTimeRandom, int numberPositions,
-                                string responseType, int stimulusSize, bool isExpositionRandom,string audioListFile, string imageListFile, bool expandImage, bool sstInterval)
+                                string responseType, double stimulusSize, bool isExpositionRandom,string audioListFile, string imageListFile, bool expandImage, bool sstInterval)
         {
 
             // ReactionProgram properties
@@ -331,7 +332,7 @@ namespace TestPlatform.Models
             this.intervalTimeRandom = intervalTimeRandom;
         }
 
-        public int StimuluSize
+        public double StimuluSize
         {
             get
             {
@@ -587,7 +588,7 @@ namespace TestPlatform.Models
                 {
                     NumExpositions = int.Parse(config[1]);
                     ExpositionTime = int.Parse(config[2]);
-                    StimuluSize = int.Parse(config[3]);
+                    StimuluSize = double.Parse(config[3]);
                     IntervalTime = int.Parse(config[4]);
                     setWordListFile(config[5]);
                     setColorListFile(config[6]);

--- a/StroopTest/Views/MatchingPages/MatchingExposition.cs
+++ b/StroopTest/Views/MatchingPages/MatchingExposition.cs
@@ -605,7 +605,7 @@ namespace TestPlatform.Views.MatchingPages
             else
             {
                 modelControl = ExpositionController.InitializeImageBox(executingTest.ProgramInUse.StimuluSize, 
-                                                                        Image.FromFile(matchingGroups.ElementAt(groupCounter).getModelName()), false);
+                                                                        Image.FromFile(matchingGroups.ElementAt(groupCounter).getModelName()), false, this);
                 size = modelControl.Size;
             }
            
@@ -650,7 +650,7 @@ namespace TestPlatform.Views.MatchingPages
                 }
                 else
                 {
-                    newStimulu = ExpositionController.InitializeImageBox(executingTest.ProgramInUse.StimuluSize, Image.FromFile(element), false);
+                    newStimulu = ExpositionController.InitializeImageBox(executingTest.ProgramInUse.StimuluSize, Image.FromFile(element), false, this);
                     newStimulu.Tag = element;
                     size = modelControl.Size;
                 }

--- a/StroopTest/Views/ReactionPages/FormReactExposition.cs
+++ b/StroopTest/Views/ReactionPages/FormReactExposition.cs
@@ -477,7 +477,7 @@ namespace TestPlatform.Views
         private void drawImage()
         {
             imgPictureBox = ExpositionController.InitializeImageBox(executingTest.ProgramInUse.StimuluSize, Image.FromFile(imagesList[imageCounter]), 
-                                                                     executingTest.ProgramInUse.ExpandImage);
+                                                                     executingTest.ProgramInUse.ExpandImage, this);
             Point screenPosition = ScreenPosition(imgPictureBox.Size);
             imgPictureBox.Location = screenPosition;
 
@@ -888,8 +888,9 @@ namespace TestPlatform.Views
         // draw on screen filled square stimulus
         private void drawFullSquareShape()
         {
-            float widthSquare = executingTest.ProgramInUse.StimuluSize;
-            float heightSquare = executingTest.ProgramInUse.StimuluSize;
+            int size = ExpositionController.CentimeterToPixel(executingTest.ProgramInUse.StimuluSize, this);
+            float widthSquare = size;
+            float heightSquare = size;
 
             SolidBrush myBrush = new SolidBrush(ColorTranslator.FromHtml(colorsList[colorCounter]));
             Graphics formGraphicsSquare = CreateGraphics();
@@ -908,8 +909,9 @@ namespace TestPlatform.Views
 
         private void drawSquareShape()
         {
-            float widthSquare = executingTest.ProgramInUse.StimuluSize;
-            float heightSquare = executingTest.ProgramInUse.StimuluSize;
+            int size = ExpositionController.CentimeterToPixel(executingTest.ProgramInUse.StimuluSize, this);
+            float widthSquare = size;
+            float heightSquare = size;
 
             Pen myPen = new Pen(ColorTranslator.FromHtml(colorsList[colorCounter]));
             Graphics formGraphicsSquare = CreateGraphics();
@@ -928,8 +930,9 @@ namespace TestPlatform.Views
 
         private void drawFullCircleShape()
         {
-            float widthEllipse = executingTest.ProgramInUse.StimuluSize;
-            float heightEllipse = executingTest.ProgramInUse.StimuluSize;
+            int size = ExpositionController.CentimeterToPixel(executingTest.ProgramInUse.StimuluSize, this);
+            float widthEllipse = size;
+            float heightEllipse = size;
 
             SolidBrush myBrush = new SolidBrush(ColorTranslator.FromHtml(colorsList[colorCounter]));
             Graphics formGraphicsEllipse = CreateGraphics();
@@ -948,8 +951,9 @@ namespace TestPlatform.Views
 
         private void drawCircleShape()
         {
-            float widthEllipse = executingTest.ProgramInUse.StimuluSize;
-            float heightEllipse = executingTest.ProgramInUse.StimuluSize;
+            int size = ExpositionController.CentimeterToPixel(executingTest.ProgramInUse.StimuluSize, this);
+            float widthEllipse = size;
+            float heightEllipse = size;
 
             Pen myPen = new Pen(ColorTranslator.FromHtml(colorsList[colorCounter]));
             Graphics formGraphicsEllipse = CreateGraphics();
@@ -1008,7 +1012,8 @@ namespace TestPlatform.Views
         private Point[] createTrianglePoints()
         {
             int[] clientMiddle = { (ClientSize.Width / 2), (ClientSize.Height / 2) };
-            int heightTriangle = executingTest.ProgramInUse.StimuluSize;
+            int size = ExpositionController.CentimeterToPixel(executingTest.ProgramInUse.StimuluSize, this);
+            int heightTriangle = size;
             Point screenPosition = this.ScreenPosition(new Size(heightTriangle, heightTriangle));
             screenPosition.X -= heightTriangle / 3;
             screenPosition.Y += heightTriangle / 2;

--- a/StroopTest/Views/ReactionPages/FormTRConfig.Designer.cs
+++ b/StroopTest/Views/ReactionPages/FormTRConfig.Designer.cs
@@ -100,7 +100,7 @@
             this.beepingCheckbox = new System.Windows.Forms.CheckBox();
             this.numExpoLabel = new System.Windows.Forms.Label();
             this.numExpo = new System.Windows.Forms.NumericUpDown();
-            this.wordSizeLabel = new System.Windows.Forms.Label();
+            this.stimulusSizeLabel = new System.Windows.Forms.Label();
             this.stimuluSize = new System.Windows.Forms.NumericUpDown();
             this.instructionsLabel = new System.Windows.Forms.Label();
             this.prgNameTextBox = new System.Windows.Forms.TextBox();
@@ -525,7 +525,7 @@
             this.expositionGroupBox.Controls.Add(this.beepingCheckbox);
             this.expositionGroupBox.Controls.Add(this.numExpoLabel);
             this.expositionGroupBox.Controls.Add(this.numExpo);
-            this.expositionGroupBox.Controls.Add(this.wordSizeLabel);
+            this.expositionGroupBox.Controls.Add(this.stimulusSizeLabel);
             this.expositionGroupBox.Controls.Add(this.stimuluSize);
             resources.ApplyResources(this.expositionGroupBox, "expositionGroupBox");
             this.expositionGroupBox.Name = "expositionGroupBox";
@@ -749,33 +749,29 @@
             this.numExpo.Validating += new System.ComponentModel.CancelEventHandler(this.numExpo_Validating);
             this.numExpo.Validated += new System.EventHandler(this.numExpo_Validated);
             // 
-            // wordSizeLabel
+            // stimulusSizeLabel
             // 
-            resources.ApplyResources(this.wordSizeLabel, "wordSizeLabel");
-            this.wordSizeLabel.Name = "wordSizeLabel";
+            resources.ApplyResources(this.stimulusSizeLabel, "stimulusSizeLabel");
+            this.stimulusSizeLabel.Name = "stimulusSizeLabel";
             // 
             // stimuluSize
             // 
+            this.stimuluSize.DecimalPlaces = 2;
             this.stimuluSize.Increment = new decimal(new int[] {
             2,
             0,
             0,
-            0});
+            65536});
             resources.ApplyResources(this.stimuluSize, "stimuluSize");
             this.stimuluSize.Maximum = new decimal(new int[] {
-            500,
-            0,
-            0,
-            0});
-            this.stimuluSize.Minimum = new decimal(new int[] {
-            10,
+            50,
             0,
             0,
             0});
             this.stimuluSize.Name = "stimuluSize";
             this.toolTip.SetToolTip(this.stimuluSize, resources.GetString("stimuluSize.ToolTip"));
             this.stimuluSize.Value = new decimal(new int[] {
-            50,
+            1,
             0,
             0,
             0});
@@ -893,7 +889,7 @@
         private System.Windows.Forms.GroupBox expositionGroupBox;
         private System.Windows.Forms.Label numExpoLabel;
         private System.Windows.Forms.NumericUpDown numExpo;
-        private System.Windows.Forms.Label wordSizeLabel;
+        private System.Windows.Forms.Label stimulusSizeLabel;
         private System.Windows.Forms.NumericUpDown stimuluSize;
         private System.Windows.Forms.Label instructionsLabel;
         private System.Windows.Forms.TextBox prgNameTextBox;

--- a/StroopTest/Views/ReactionPages/FormTRConfig.cs
+++ b/StroopTest/Views/ReactionPages/FormTRConfig.cs
@@ -56,7 +56,7 @@ namespace TestPlatform.Views
             intervalTime.Value = editProgram.IntervalTime;
             beepingCheckbox.Checked = editProgram.IsBeeping;
             beepDuration.Value = editProgram.BeepDuration;
-            stimuluSize.Value = editProgram.StimuluSize;
+            stimuluSize.Value = (decimal) editProgram.StimuluSize;
             fontSizeUpDown.Value = editProgram.FontSize;
             positionsBox.SelectedIndex = editProgram.NumberPositions - 1;
             expandImageCheck.Checked = editProgram.ExpandImage;
@@ -383,7 +383,7 @@ namespace TestPlatform.Views
                 // Program type "shapes"
                 case 0:
                     newProgram = new ReactionProgram(prgNameTextBox.Text, Convert.ToInt32(expoTime.Value),
-                                                    Convert.ToInt32(numExpo.Value), Convert.ToInt32(stimuluSize.Value),
+                                                    Convert.ToInt32(numExpo.Value), Convert.ToDouble(stimuluSize.Value),
                                                     Convert.ToInt32(intervalTime.Value),
                                                     beepingCheckbox.Checked,
                                                     Convert.ToInt32(beepDuration.Value), stimulusColorCheck(),
@@ -394,7 +394,7 @@ namespace TestPlatform.Views
                 // Program type "words"
                 case 1:
                     newProgram = new ReactionProgram(prgNameTextBox.Text, Convert.ToInt32(expoTime.Value),
-                                                    Convert.ToInt32(numExpo.Value), Convert.ToInt32(stimuluSize.Value),
+                                                    Convert.ToInt32(numExpo.Value), Convert.ToInt32(fontSizeUpDown.Value),
                                                     Convert.ToInt32(intervalTime.Value),
                                                     beepingCheckbox.Checked,
                                                     Convert.ToInt32(beepDuration.Value), stimulusColorCheck(),
@@ -406,7 +406,7 @@ namespace TestPlatform.Views
                 
                 // Program type "images"
                 case 2:
-                    newProgram = new ReactionProgram(prgNameTextBox.Text, Convert.ToInt32(expoTime.Value), Convert.ToInt32(numExpo.Value), Convert.ToInt32(stimuluSize.Value), 
+                    newProgram = new ReactionProgram(prgNameTextBox.Text, Convert.ToInt32(expoTime.Value), Convert.ToInt32(numExpo.Value), Convert.ToDouble(stimuluSize.Value), 
                                                      Convert.ToInt32(intervalTime.Value), beepingCheckbox.Checked, Convert.ToInt32(beepDuration.Value),
                                                      fixPointValue(), bgColorButton.Text, fixPointColor(), rndIntervalCheck.Checked, openImgListButton.Text, 
                                                      randomBeepCheck.Checked, Convert.ToInt32(positionsBox.Text), responseType(), isRandomExposition.Checked, 
@@ -415,7 +415,7 @@ namespace TestPlatform.Views
                 
                 // Program type "imageAndWord"
                 case 3:
-                    newProgram = new ReactionProgram(prgNameTextBox.Text, Convert.ToInt32(expoTime.Value), Convert.ToInt32(numExpo.Value), Convert.ToInt32(stimuluSize.Value),
+                    newProgram = new ReactionProgram(prgNameTextBox.Text, Convert.ToInt32(expoTime.Value), Convert.ToInt32(numExpo.Value), Convert.ToDouble(stimuluSize.Value),
                                                      Convert.ToInt32(intervalTime.Value), beepingCheckbox.Checked, Convert.ToInt32(beepDuration.Value),
                                                      fixPointValue(), bgColorButton.Text, fixPointColor(), rndIntervalCheck.Checked,
                                                      openImgListButton.Text, openWordListButton.Text, openColorListButton.Text, randomBeepCheck.Checked,
@@ -437,7 +437,7 @@ namespace TestPlatform.Views
                 case 5:
                     newProgram = new ReactionProgram(prgNameTextBox.Text, Convert.ToInt32(expoTime.Value), Convert.ToInt32(numExpo.Value), Convert.ToInt32(intervalTime.Value),
                                                     fixPointValue(), bgColorButton.Text, fixPointColor(), rndIntervalCheck.Checked, Convert.ToInt32(positionsBox.Text),
-                                                    responseType(), Convert.ToInt32(stimuluSize.Value), isRandomExposition.Checked, openAudioListButton.Text, 
+                                                    responseType(), Convert.ToDouble(stimuluSize.Value), isRandomExposition.Checked, openAudioListButton.Text, 
                                                     openImgListButton.Text, expandImageCheck.Checked, sstCheckBox.Checked);
                     break;
                 

--- a/StroopTest/Views/ReactionPages/FormTRConfig.en-US.resx
+++ b/StroopTest/Views/ReactionPages/FormTRConfig.en-US.resx
@@ -214,8 +214,8 @@ Color:</value>
   <data name="numExpoLabel.Text" xml:space="preserve">
     <value>Number of Attempts:</value>
   </data>
-  <data name="wordSizeLabel.Text" xml:space="preserve">
-    <value>Stimulus size:</value>
+  <data name="stimulusSizeLabel.Text" xml:space="preserve">
+    <value>Stimulus size (cm):</value>
   </data>
   <data name="instructionsLabel.Text" xml:space="preserve">
     <value>Instructions:</value>
@@ -230,7 +230,7 @@ Color:</value>
     <value>save</value>
   </data>
   <data name="fontSizeLabel.Text" xml:space="preserve">
-    <value>Font Size:</value>
+    <value>Font Size (pt):</value>
   </data>
   <data name="fixPointGroupBox.Text" xml:space="preserve">
     <value>Fix Point</value>

--- a/StroopTest/Views/ReactionPages/FormTRConfig.es-ES.resx
+++ b/StroopTest/Views/ReactionPages/FormTRConfig.es-ES.resx
@@ -213,8 +213,8 @@
   <data name="numExpoLabel.Text" xml:space="preserve">
     <value>Número de intentos:</value>
   </data>
-  <data name="wordSizeLabel.Text" xml:space="preserve">
-    <value>Tamaño del Estímulo:</value>
+  <data name="stimulusSizeLabel.Text" xml:space="preserve">
+    <value>Tamaño del Estímulo (cm):</value>
   </data>
   <data name="instructionsLabel.Text" xml:space="preserve">
     <value>Instrucciones:</value>
@@ -226,6 +226,6 @@
     <value>cancelar</value>
   </data>
   <data name="fontSizeLabel.Text" xml:space="preserve">
-    <value>Tamaño de Letra:</value>
+    <value>Tamaño de Letra (pt):</value>
   </data>
 </root>

--- a/StroopTest/Views/ReactionPages/FormTRConfig.pt-BR.resx
+++ b/StroopTest/Views/ReactionPages/FormTRConfig.pt-BR.resx
@@ -214,8 +214,8 @@ Ponto:</value>
   <data name="numExpoLabel.Text" xml:space="preserve">
     <value>Número de Tentativas:</value>
   </data>
-  <data name="wordSizeLabel.Text" xml:space="preserve">
-    <value>Tamanho do Estímulo:</value>
+  <data name="stimulusSizeLabel.Text" xml:space="preserve">
+    <value>Tamanho do Estímulo (cm):</value>
   </data>
   <data name="instructionsLabel.Text" xml:space="preserve">
     <value>Instruções:</value>
@@ -230,7 +230,7 @@ Ponto:</value>
     <value>salvar</value>
   </data>
   <data name="fontSizeLabel.Text" xml:space="preserve">
-    <value>Tamanho da Fonte:</value>
+    <value>Tamanho da Fonte (pt):</value>
   </data>
   <data name="fixPointGroupBox.Text" xml:space="preserve">
     <value>Ponto de Fixação</value>

--- a/StroopTest/Views/ReactionPages/FormTRConfig.resx
+++ b/StroopTest/Views/ReactionPages/FormTRConfig.resx
@@ -1460,7 +1460,7 @@ Ponto:</value>
     <value>2</value>
   </data>
   <data name="fontSizeUpDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>144, 81</value>
+    <value>197, 81</value>
   </data>
   <data name="fontSizeUpDown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -2096,38 +2096,38 @@ Ponto:</value>
   <data name="&gt;&gt;numExpo.ZOrder" xml:space="preserve">
     <value>23</value>
   </data>
-  <data name="wordSizeLabel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="stimulusSizeLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="wordSizeLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="stimulusSizeLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="wordSizeLabel.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="stimulusSizeLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>11, 55</value>
   </data>
-  <data name="wordSizeLabel.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="stimulusSizeLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>149, 17</value>
   </data>
-  <data name="wordSizeLabel.TabIndex" type="System.Int32, mscorlib">
+  <data name="stimulusSizeLabel.TabIndex" type="System.Int32, mscorlib">
     <value>159</value>
   </data>
-  <data name="wordSizeLabel.Text" xml:space="preserve">
+  <data name="stimulusSizeLabel.Text" xml:space="preserve">
     <value>Tamanho do Estímulo:</value>
   </data>
-  <data name="&gt;&gt;wordSizeLabel.Name" xml:space="preserve">
-    <value>wordSizeLabel</value>
+  <data name="&gt;&gt;stimulusSizeLabel.Name" xml:space="preserve">
+    <value>stimulusSizeLabel</value>
   </data>
-  <data name="&gt;&gt;wordSizeLabel.Type" xml:space="preserve">
+  <data name="&gt;&gt;stimulusSizeLabel.Type" xml:space="preserve">
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;wordSizeLabel.Parent" xml:space="preserve">
+  <data name="&gt;&gt;stimulusSizeLabel.Parent" xml:space="preserve">
     <value>expositionGroupBox</value>
   </data>
-  <data name="&gt;&gt;wordSizeLabel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;stimulusSizeLabel.ZOrder" xml:space="preserve">
     <value>24</value>
   </data>
   <data name="stimuluSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>165, 52</value>
+    <value>199, 52</value>
   </data>
   <data name="stimuluSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 2, 3, 2</value>
@@ -2139,7 +2139,7 @@ Ponto:</value>
     <value>3</value>
   </data>
   <data name="stimuluSize.ToolTip" xml:space="preserve">
-    <value>O valor está em pixels e deve estar entre 10 e 500.</value>
+    <value>O valor está em centímetros e deve estar entre 0,1 e 50</value>
   </data>
   <data name="&gt;&gt;stimuluSize.Name" xml:space="preserve">
     <value>stimuluSize</value>


### PR DESCRIPTION
Foram feitas as mudanças para que fosse possível ao usuário selecionar o tamanho do estímulo (imagem e formas) em centímetros, conversões são feitas de volta para pixels na hora da exposição (cada computador a depender da tela e da densidade de pixels vai ter uma conversão diferente, logo ela deve ser feita em tempo de execução